### PR TITLE
Activation Message Redundancy Fix

### DIFF
--- a/badgeos-add-on.php
+++ b/badgeos-add-on.php
@@ -129,6 +129,11 @@ class BadgeOS_Addon {
 
 			// Deactivate our plugin
 			deactivate_plugins( $this->basename );
+			
+			// Stop Wordpress from displaying "Plugin Activated" message in addition to plugin activation error message when plugin gets deactivated.
+			if ( isset( $_GET['activate'] ) ) 
+            unset( $_GET['activate'] );
+
 		}
 
 	} /* maybe_disable_plugin() */


### PR DESCRIPTION
I've fixed an issue where the WordPress "Plugin Activated" message shows up in addition to the error message that displays when a boilerplate plugin gets deactivated.